### PR TITLE
refactor exit

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,9 @@ authors = ["honhimw <honhimw@outlook.com>"]
 rust-version = "1.81.0"
 build = "build.rs"
 
+[workspace]
+members = ["ratisui-macros"]
+
 [workspace.dependencies]
 log = "0.4"
 redis = "0.27"
@@ -67,6 +70,7 @@ tree-sitter-ron = { git = "https://github.com/honhimW/tree-sitter-ron" }
 russh = { version = "0.49", default-features = false }
 async-trait = "0.1.83"
 paste = "1"
+ratisui-macros = { path = "ratisui-macros" }
 
 [build-dependencies]
 cc = "*"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ tree-sitter-html = { git = "https://github.com/honhimW/tree-sitter-html" }
 tree-sitter-ron = { git = "https://github.com/honhimW/tree-sitter-ron" }
 russh = { version = "0.49", default-features = false }
 async-trait = "0.1.83"
+paste = "1"
 
 [build-dependencies]
 cc = "*"

--- a/ratisui-macros/Cargo.toml
+++ b/ratisui-macros/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ratisui-macros"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+proc-macro = true
+
+[dependencies]
+quote = "1"
+syn = "2"

--- a/ratisui-macros/Cargo.toml
+++ b/ratisui-macros/Cargo.toml
@@ -8,4 +8,3 @@ proc-macro = true
 
 [dependencies]
 quote = "1"
-syn = "2"

--- a/ratisui-macros/src/lib.rs
+++ b/ratisui-macros/src/lib.rs
@@ -1,16 +1,16 @@
-use proc_macro::{Literal, TokenStream, TokenTree};
+use proc_macro::TokenStream;
 use quote::quote;
-use syn::{parse_macro_input, Ident};
+
+// #[proc_macro]
+// pub fn characterize(input: TokenStream) -> TokenStream {
+//     let input = parse_macro_input!(input as Ident);
+//     let char_lit = input.to_string().chars().next().unwrap();
+//     let expanded = quote! { #char_lit };
+//     TokenStream::from(expanded)
+// }
 
 #[proc_macro]
-pub fn charify(input: TokenStream) -> TokenStream {
-    let input = parse_macro_input!(input as Ident);
-    let char_lit = input.to_string().chars().next().unwrap();
-    let expanded = quote! { #char_lit };
-    TokenStream::from(expanded)
-}
-#[proc_macro]
-pub fn charify2(input: TokenStream) -> TokenStream {
+pub fn characterize(input: TokenStream) -> TokenStream {
     let mut iter = input.into_iter();
     match iter.next() {
         None => {

--- a/ratisui-macros/src/lib.rs
+++ b/ratisui-macros/src/lib.rs
@@ -1,0 +1,27 @@
+use proc_macro::{Literal, TokenStream, TokenTree};
+use quote::quote;
+use syn::{parse_macro_input, Ident};
+
+#[proc_macro]
+pub fn charify(input: TokenStream) -> TokenStream {
+    let input = parse_macro_input!(input as Ident);
+    let char_lit = input.to_string().chars().next().unwrap();
+    let expanded = quote! { #char_lit };
+    TokenStream::from(expanded)
+}
+#[proc_macro]
+pub fn charify2(input: TokenStream) -> TokenStream {
+    let mut iter = input.into_iter();
+    match iter.next() {
+        None => {
+            let ch = 'a';
+            let expanded = quote! { #ch };
+            TokenStream::from(expanded)
+        }
+        Some(next) => {
+            let ch = next.to_string().chars().next().unwrap_or('a');
+            let expanded = quote! { #ch };
+            TokenStream::from(expanded)
+        }
+    }
+}

--- a/src/bus.rs
+++ b/src/bus.rs
@@ -89,6 +89,7 @@ pub struct GlobalChannel {
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum GlobalEvent {
+    Exit,
     ClientChanged,
     #[allow(unused)]
     Dynamic(String),

--- a/src/components/highlight_value.rs
+++ b/src/components/highlight_value.rs
@@ -447,7 +447,7 @@ mod high_light_test {
         }).to_string();
         assert_eq!(r#"{"tags":["1",2,"3"]}"#, json);
         let mut processor = super::HighlightProcessor::new(json, Some(super::ContentType::Json));
-        let x = processor.process()?;
+        let _ = processor.process()?;
         assert_eq!(
             r#"{
   "tags": [

--- a/src/components/redis_cli.rs
+++ b/src/components/redis_cli.rs
@@ -779,7 +779,19 @@ static COMMANDS: Lazy<Vec<CompletionItem>> = Lazy::new(|| {
         range: (0, -1),
         insert_text: "clear".to_string(),
     };
+    let exit_item = CompletionItem {
+        kind: CompletionItemKind::Other,
+        label: Label {
+            label: "EXIT".to_string(),
+            detail: Some("exit the application".to_string()),
+            description: None,
+        },
+        parameters: vec![],
+        range: (0, -1),
+        insert_text: "exit".to_string(),
+    };
     items.push(clear_item);
+    items.push(exit_item);
     if let Ok(commands) = result {
         for command in commands.iter() {
             let cmd = command.get("command").expect("command is empty");

--- a/src/context.rs
+++ b/src/context.rs
@@ -282,7 +282,7 @@ impl Listenable for Context {
             self.show_server_switcher = true;
             return Ok(true);
         }
-        Ok(true)
+        Ok(false)
     }
 
     fn on_app_event(&mut self, app_event: AppEvent) -> Result<()> {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,3 +4,4 @@ pub mod utils;
 pub mod bus;
 pub mod ssh_tunnel;
 pub mod theme;
+pub mod marcos;

--- a/src/main.rs
+++ b/src/main.rs
@@ -31,6 +31,7 @@ mod utils;
 mod bus;
 mod ssh_tunnel;
 mod theme;
+mod marcos;
 
 use crate::app::{App, AppEvent, AppState, Listenable, Renderable};
 use crate::components::fps::FpsCalculator;
@@ -45,6 +46,7 @@ use std::time::Duration;
 use tokio::time::{interval};
 use crate::app::AppState::Closed;
 use crate::bus::{publish_msg, subscribe_global_channel, try_take_msg, Message};
+use crate::marcos::KeyAsserter;
 use crate::tui::TerminalBackEnd;
 
 #[tokio::main]
@@ -165,7 +167,7 @@ async fn run(mut app: App, mut terminal: TerminalBackEnd, config: Configuration)
                     InputEvent::Input(input) => {
                         if let Event::Key(key_event) = input {
                             if key_event.kind == KeyEventKind::Press {
-                                if key_event.modifiers == KeyModifiers::CONTROL && key_event.code == KeyCode::Char('c') {
+                                if key_event.is_c_c() {
                                     app.state = AppState::Closing;
                                     app.context.on_app_event(AppEvent::Destroy)?;
                                 } else if key_event.modifiers == KeyModifiers::CONTROL && key_event.code == KeyCode::F(5) {

--- a/src/marcos.rs
+++ b/src/marcos.rs
@@ -1,0 +1,66 @@
+#![allow(dead_code)]
+
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use paste::paste;
+
+macro_rules! key_asserter {
+    ( $( $char:tt ),* ) => {
+
+        pub trait KeyAsserter {
+            $(
+                paste! {
+                    fn [<is_n_$char>](&self) -> bool;
+                    fn [<is_c_$char>](&self) -> bool;
+                    fn [<is_s_$char>](&self) -> bool;
+                    fn [<is_a_$char>](&self) -> bool;
+                    fn [<is_cs_$char>](&self) -> bool;
+                    fn [<is_ca_$char>](&self) -> bool;
+                    fn [<is_sa_$char>](&self) -> bool;
+                }
+            )*
+        }
+
+        impl KeyAsserter for KeyEvent {
+            $(
+                paste! {
+                    fn [<is_n_$char>](&self) -> bool {
+                        self.modifiers.is_empty() && self.code == KeyCode::Char(stringify!($char).chars().next().unwrap())
+                    }
+                    fn [<is_c_$char>](&self) -> bool {
+                        self.modifiers.contains(KeyModifiers::CONTROL) && self.code == KeyCode::Char(stringify!($char).chars().next().unwrap())
+                    }
+                    fn [<is_s_$char>](&self) -> bool {
+                        self.modifiers.contains(KeyModifiers::SHIFT) && self.code == KeyCode::Char(stringify!($char).chars().next().unwrap())
+                    }
+                    fn [<is_a_$char>](&self) -> bool {
+                        self.modifiers.contains(KeyModifiers::ALT) && self.code == KeyCode::Char(stringify!($char).chars().next().unwrap())
+                    }
+                    fn [<is_cs_$char>](&self) -> bool {
+                        self.modifiers.contains(KeyModifiers::CONTROL) && self.modifiers.contains(KeyModifiers::SHIFT) && self.code == KeyCode::Char(stringify!($char).chars().next().unwrap())
+                    }
+                    fn [<is_ca_$char>](&self) -> bool {
+                        self.modifiers.contains(KeyModifiers::SHIFT) && self.modifiers.contains(KeyModifiers::ALT) && self.code == KeyCode::Char(stringify!($char).chars().next().unwrap())
+                    }
+                    fn [<is_sa_$char>](&self) -> bool {
+                        self.modifiers.contains(KeyModifiers::SHIFT) && self.modifiers.contains(KeyModifiers::ALT) && self.code == KeyCode::Char(stringify!($char).chars().next().unwrap())
+                    }
+                }
+            )*
+        }
+    };
+}
+key_asserter!(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_key_asserter() {
+        let event = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL);
+        assert!(event.is_c_a());
+
+        let event = KeyEvent::new(KeyCode::Char('0'), KeyModifiers::empty());
+        assert!(event.is_n_0());
+    }
+}

--- a/src/marcos.rs
+++ b/src/marcos.rs
@@ -5,6 +5,9 @@ use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use ratisui_macros::characterize;
 
 /// Declare key asserter
+/// ```rust
+/// key_asserter!(a);
+/// ```
 /// Macro expansion:
 /// ```rust
 /// pub trait KeyAsserter {

--- a/src/marcos.rs
+++ b/src/marcos.rs
@@ -2,7 +2,7 @@
 
 use paste::paste;
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
-use ratisui_macros::charify2;
+use ratisui_macros::characterize;
 
 /// Declare key asserter
 /// Macro expansion:
@@ -18,34 +18,34 @@ use ratisui_macros::charify2;
 /// }
 /// impl KeyAsserter for KeyEvent {
 ///     fn is_n_a(&self) -> bool {
-///         self.modifiers.is_empty() && self.code == KeyCode::Char("a".chars().next().unwrap())
+///         self.modifiers.is_empty() && self.code == KeyCode::Char('a')
 ///     }
 ///     fn is_c_a(&self) -> bool {
 ///         self.modifiers.contains(KeyModifiers::CONTROL)
-///             && self.code == KeyCode::Char("a".chars().next().unwrap())
+///             && self.code == KeyCode::Char('a')
 ///     }
 ///     fn is_s_a(&self) -> bool {
 ///         self.modifiers.contains(KeyModifiers::SHIFT)
-///             && self.code == KeyCode::Char("a".chars().next().unwrap())
+///             && self.code == KeyCode::Char('a')
 ///     }
 ///     fn is_a_a(&self) -> bool {
 ///         self.modifiers.contains(KeyModifiers::ALT)
-///             && self.code == KeyCode::Char("a".chars().next().unwrap())
+///             && self.code == KeyCode::Char('a')
 ///     }
 ///     fn is_cs_a(&self) -> bool {
 ///         self.modifiers.contains(KeyModifiers::CONTROL)
 ///             && self.modifiers.contains(KeyModifiers::SHIFT)
-///             && self.code == KeyCode::Char("a".chars().next().unwrap())
+///             && self.code == KeyCode::Char('a')
 ///     }
 ///     fn is_ca_a(&self) -> bool {
 ///         self.modifiers.contains(KeyModifiers::SHIFT)
 ///             && self.modifiers.contains(KeyModifiers::ALT)
-///             && self.code == KeyCode::Char("a".chars().next().unwrap())
+///             && self.code == KeyCode::Char('a')
 ///     }
 ///     fn is_sa_a(&self) -> bool {
 ///         self.modifiers.contains(KeyModifiers::SHIFT)
 ///             && self.modifiers.contains(KeyModifiers::ALT)
-///             && self.code == KeyCode::Char("a".chars().next().unwrap())
+///             && self.code == KeyCode::Char('a')
 ///     }
 /// }
 //// ```
@@ -70,25 +70,25 @@ macro_rules! key_asserter {
             $(
                 paste! {
                     fn [<is_n_$char>](&self) -> bool {
-                        self.modifiers.is_empty() && self.code == KeyCode::Char(charify2!($char))
+                        self.modifiers.is_empty() && self.code == KeyCode::Char(characterize!($char))
                     }
                     fn [<is_c_$char>](&self) -> bool {
-                        self.modifiers.contains(KeyModifiers::CONTROL) && self.code == KeyCode::Char(charify2!($char))
+                        self.modifiers.contains(KeyModifiers::CONTROL) && self.code == KeyCode::Char(characterize!($char))
                     }
                     fn [<is_s_$char>](&self) -> bool {
-                        self.modifiers.contains(KeyModifiers::SHIFT) && self.code == KeyCode::Char(charify2!($char))
+                        self.modifiers.contains(KeyModifiers::SHIFT) && self.code == KeyCode::Char(characterize!($char))
                     }
                     fn [<is_a_$char>](&self) -> bool {
-                        self.modifiers.contains(KeyModifiers::ALT) && self.code == KeyCode::Char(charify2!($char))
+                        self.modifiers.contains(KeyModifiers::ALT) && self.code == KeyCode::Char(characterize!($char))
                     }
                     fn [<is_cs_$char>](&self) -> bool {
-                        self.modifiers.contains(KeyModifiers::CONTROL) && self.modifiers.contains(KeyModifiers::SHIFT) && self.code == KeyCode::Char(charify2!($char))
+                        self.modifiers.contains(KeyModifiers::CONTROL | KeyModifiers::SHIFT) && self.code == KeyCode::Char(characterize!($char))
                     }
                     fn [<is_ca_$char>](&self) -> bool {
-                        self.modifiers.contains(KeyModifiers::SHIFT) && self.modifiers.contains(KeyModifiers::ALT) && self.code == KeyCode::Char(charify2!($char))
+                        self.modifiers.contains(KeyModifiers::CONTROL | KeyModifiers::ALT) && self.code == KeyCode::Char(characterize!($char))
                     }
                     fn [<is_sa_$char>](&self) -> bool {
-                        self.modifiers.contains(KeyModifiers::SHIFT) && self.modifiers.contains(KeyModifiers::ALT) && self.code == KeyCode::Char(charify2!($char))
+                        self.modifiers.contains(KeyModifiers::SHIFT | KeyModifiers::ALT) && self.code == KeyCode::Char(characterize!($char))
                     }
                 }
             )*
@@ -96,22 +96,28 @@ macro_rules! key_asserter {
     };
 }
 
-key_asserter!(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
+key_asserter!(
+    a, b, c, d, e, f, g, h, i, j,
+    k, l, m, n, o, p, q, r, s, t,
+    u, v, w, x, y, z,
+    0, 1, 2, 3, 4, 5, 6, 7, 8, 9
+);
 
 #[cfg(test)]
 mod test {
-    use ratisui_macros::charify;
+    use ratisui_macros::characterize;
     use super::*;
 
     #[test]
     fn test_key_asserter() {
-        let x = charify!(a);
-        println!("{}", x);
+        assert_eq!(characterize!(a), 'a');
         let event = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL);
+        event.modifiers.contains(KeyModifiers::CONTROL | KeyModifiers::ALT);
         assert!(event.is_c_a());
-
         let event = KeyEvent::new(KeyCode::Char('0'), KeyModifiers::empty());
         assert!(event.is_n_0());
+        let event = KeyEvent::new(KeyCode::Char('z'), KeyModifiers::CONTROL | KeyModifiers::SHIFT);
+        assert!(event.is_cs_z());
     }
 
 }

--- a/src/marcos.rs
+++ b/src/marcos.rs
@@ -1,8 +1,54 @@
 #![allow(dead_code)]
 
-use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use paste::paste;
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use ratisui_macros::charify2;
 
+/// Declare key asserter
+/// Macro expansion:
+/// ```rust
+/// pub trait KeyAsserter {
+///     fn is_n_a(&self) -> bool;
+///     fn is_c_a(&self) -> bool;
+///     fn is_s_a(&self) -> bool;
+///     fn is_a_a(&self) -> bool;
+///     fn is_cs_a(&self) -> bool;
+///     fn is_ca_a(&self) -> bool;
+///     fn is_sa_a(&self) -> bool;
+/// }
+/// impl KeyAsserter for KeyEvent {
+///     fn is_n_a(&self) -> bool {
+///         self.modifiers.is_empty() && self.code == KeyCode::Char("a".chars().next().unwrap())
+///     }
+///     fn is_c_a(&self) -> bool {
+///         self.modifiers.contains(KeyModifiers::CONTROL)
+///             && self.code == KeyCode::Char("a".chars().next().unwrap())
+///     }
+///     fn is_s_a(&self) -> bool {
+///         self.modifiers.contains(KeyModifiers::SHIFT)
+///             && self.code == KeyCode::Char("a".chars().next().unwrap())
+///     }
+///     fn is_a_a(&self) -> bool {
+///         self.modifiers.contains(KeyModifiers::ALT)
+///             && self.code == KeyCode::Char("a".chars().next().unwrap())
+///     }
+///     fn is_cs_a(&self) -> bool {
+///         self.modifiers.contains(KeyModifiers::CONTROL)
+///             && self.modifiers.contains(KeyModifiers::SHIFT)
+///             && self.code == KeyCode::Char("a".chars().next().unwrap())
+///     }
+///     fn is_ca_a(&self) -> bool {
+///         self.modifiers.contains(KeyModifiers::SHIFT)
+///             && self.modifiers.contains(KeyModifiers::ALT)
+///             && self.code == KeyCode::Char("a".chars().next().unwrap())
+///     }
+///     fn is_sa_a(&self) -> bool {
+///         self.modifiers.contains(KeyModifiers::SHIFT)
+///             && self.modifiers.contains(KeyModifiers::ALT)
+///             && self.code == KeyCode::Char("a".chars().next().unwrap())
+///     }
+/// }
+//// ```
 macro_rules! key_asserter {
     ( $( $char:tt ),* ) => {
 
@@ -24,43 +70,48 @@ macro_rules! key_asserter {
             $(
                 paste! {
                     fn [<is_n_$char>](&self) -> bool {
-                        self.modifiers.is_empty() && self.code == KeyCode::Char(stringify!($char).chars().next().unwrap())
+                        self.modifiers.is_empty() && self.code == KeyCode::Char(charify2!($char))
                     }
                     fn [<is_c_$char>](&self) -> bool {
-                        self.modifiers.contains(KeyModifiers::CONTROL) && self.code == KeyCode::Char(stringify!($char).chars().next().unwrap())
+                        self.modifiers.contains(KeyModifiers::CONTROL) && self.code == KeyCode::Char(charify2!($char))
                     }
                     fn [<is_s_$char>](&self) -> bool {
-                        self.modifiers.contains(KeyModifiers::SHIFT) && self.code == KeyCode::Char(stringify!($char).chars().next().unwrap())
+                        self.modifiers.contains(KeyModifiers::SHIFT) && self.code == KeyCode::Char(charify2!($char))
                     }
                     fn [<is_a_$char>](&self) -> bool {
-                        self.modifiers.contains(KeyModifiers::ALT) && self.code == KeyCode::Char(stringify!($char).chars().next().unwrap())
+                        self.modifiers.contains(KeyModifiers::ALT) && self.code == KeyCode::Char(charify2!($char))
                     }
                     fn [<is_cs_$char>](&self) -> bool {
-                        self.modifiers.contains(KeyModifiers::CONTROL) && self.modifiers.contains(KeyModifiers::SHIFT) && self.code == KeyCode::Char(stringify!($char).chars().next().unwrap())
+                        self.modifiers.contains(KeyModifiers::CONTROL) && self.modifiers.contains(KeyModifiers::SHIFT) && self.code == KeyCode::Char(charify2!($char))
                     }
                     fn [<is_ca_$char>](&self) -> bool {
-                        self.modifiers.contains(KeyModifiers::SHIFT) && self.modifiers.contains(KeyModifiers::ALT) && self.code == KeyCode::Char(stringify!($char).chars().next().unwrap())
+                        self.modifiers.contains(KeyModifiers::SHIFT) && self.modifiers.contains(KeyModifiers::ALT) && self.code == KeyCode::Char(charify2!($char))
                     }
                     fn [<is_sa_$char>](&self) -> bool {
-                        self.modifiers.contains(KeyModifiers::SHIFT) && self.modifiers.contains(KeyModifiers::ALT) && self.code == KeyCode::Char(stringify!($char).chars().next().unwrap())
+                        self.modifiers.contains(KeyModifiers::SHIFT) && self.modifiers.contains(KeyModifiers::ALT) && self.code == KeyCode::Char(charify2!($char))
                     }
                 }
             )*
         }
     };
 }
+
 key_asserter!(a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u, v, w, x, y, z, 0, 1, 2, 3, 4, 5, 6, 7, 8, 9);
 
 #[cfg(test)]
 mod test {
+    use ratisui_macros::charify;
     use super::*;
 
     #[test]
     fn test_key_asserter() {
+        let x = charify!(a);
+        println!("{}", x);
         let event = KeyEvent::new(KeyCode::Char('a'), KeyModifiers::CONTROL);
         assert!(event.is_c_a());
 
         let event = KeyEvent::new(KeyCode::Char('0'), KeyModifiers::empty());
         assert!(event.is_n_0());
     }
+
 }

--- a/src/redis_opt.rs
+++ b/src/redis_opt.rs
@@ -57,7 +57,7 @@ where
         });
         Ok(())
     } else {
-        Ok(())
+        Err(anyhow!("redis not connected"))
     }
 }
 

--- a/src/ssh_tunnel.rs
+++ b/src/ssh_tunnel.rs
@@ -130,7 +130,7 @@ mod test {
         tokio::spawn(async move {
             let now = Instant::now();
             loop {
-                if let Ok((mut stream, _)) = listener.accept().await {
+                if let Ok((stream, _)) = listener.accept().await {
                     println!("{:?} {:?}", now.elapsed(), stream);
                 } else {
                     println!("No connection");
@@ -138,13 +138,13 @@ mod test {
             }
         });
         tokio::time::sleep(Duration::from_secs(1)).await;
-        let x = TcpStream::connect(addr).await?;
+        let _ = TcpStream::connect(addr).await?;
         tokio::time::sleep(Duration::from_secs(1)).await;
-        let x = TcpStream::connect(addr).await?;
+        let _ = TcpStream::connect(addr).await?;
         tokio::time::sleep(Duration::from_secs(1)).await;
-        let x = TcpStream::connect(addr).await?;
+        let _ = TcpStream::connect(addr).await?;
         tokio::time::sleep(Duration::from_secs(1)).await;
-        let x = TcpStream::connect(addr).await?;
+        let _ = TcpStream::connect(addr).await?;
         tokio::time::sleep(Duration::from_secs(1)).await;
         Ok(())
     }


### PR DESCRIPTION
Enhance the user experience of CLI operations.

- Add `exit` command for exit the application.
- Exit the application by calling `publish_event(GlobalEvent::Exit)` instead of prioritizing `ctrl+c` for exiting.

> [!warning]
> Due to not prioritizing the exit key, this may cause the application to fail to exit (the signal might be intercepted erroneously).