### PR TITLE
perf: [Explorer] scan on enormous keys

### DIFF
--- a/ratisui-core/src/redis_opt.rs
+++ b/ratisui-core/src/redis_opt.rs
@@ -751,6 +751,7 @@ impl RedisOperations {
                     let mut vec: Vec<String> = vec![];
                     while let Some(item) = iter.next_item().await {
                         vec.push(item);
+                        if vec.len() >= count { break; }
                     }
                     all_node_keys.extend(vec);
                 }
@@ -762,6 +763,7 @@ impl RedisOperations {
             let mut vec: Vec<String> = vec![];
             while let Some(item) = iter.next_item().await {
                 vec.push(item);
+                if vec.len() >= count { break; }
             }
             Ok(vec)
         }


### PR DESCRIPTION
Only a number of keys smaller than `scan_size` during a Redis scan, instead of scanning all of them iteratively.