### PR TITLE
Potential fix for code scanning alert no. 9: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Release
 
+permissions:
+  contents: write
+  packages: write
+
 on:
   workflow_dispatch:
     inputs:


### PR DESCRIPTION
Potential fix for [https://github.com/honhimW/ratisui/security/code-scanning/9](https://github.com/honhimW/ratisui/security/code-scanning/9)

To fix the issue, we will add a `permissions` block at the workflow level to define the minimal permissions required. Based on the workflow's actions, the following permissions are necessary:
- `contents: read` for accessing repository contents.
- `contents: write` for creating releases.
- `packages: write` for uploading release assets.

The `permissions` block will be added at the root of the workflow file to apply to all jobs unless overridden.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

好的，这是翻译成中文的 pull request 总结：

## Sourcery 总结

在发布工作流程中添加权限块，以定义所需的最低权限并解决安全代码扫描警报

Bug 修复：
- 为 GitHub Actions 发布工作流程指定最低权限，以解决代码扫描警报 no. 9

CI：
- 在 release.yml 中添加根级别的权限块，授予 contents: write 和 packages: write 权限

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add a permissions block to the release workflow to define minimal required permissions and address the security code scanning alert

Bug Fixes:
- Specify minimal permissions for the GitHub Actions release workflow to resolve code scanning alert no. 9

CI:
- Add a root-level permissions block in release.yml granting contents: write and packages: write

</details>