### PR TITLE
[CLI] Add binary support

### DIFF
--- a/ratisui-core/Cargo.toml
+++ b/ratisui-core/Cargo.toml
@@ -34,6 +34,7 @@ strum = { workspace = true, features = ["derive"] }
 ron = { version = "0.10.1", features = ["default"] }
 dirs = "6.0.0"
 base64 = "0.22.1"
+hex = "0.4.3"
 clap = { version = "4.5", features = ["cargo"] }
 tokio = { workspace = true, features = ["full"] }
 chrono = "0.4.39"

--- a/src/components/redis_cli.rs
+++ b/src/components/redis_cli.rs
@@ -198,8 +198,20 @@ static COMMANDS: Lazy<Vec<CompletionItem>> = Lazy::new(|| {
         range: (0, -1),
         insert_text: "exit".to_string(),
     };
+    let help_item = CompletionItem {
+        kind: CompletionItemKind::Other,
+        label: Label {
+            label: "HELP".to_string(),
+            detail: Some("print help".to_string()),
+            description: None,
+        },
+        parameters: vec![],
+        range: (0, -1),
+        insert_text: "help".to_string(),
+    };
     items.push(clear_item);
     items.push(exit_item);
+    items.push(help_item);
     if let Ok(commands) = result {
         resolve_commands(commands, &mut items);
     }


### PR DESCRIPTION
Binary:
-  base64:        base64#YmFzZTY0#
-  hex:           hex#686578#
-  file:          fs#/home/user/file#
                 fs#C:\Users\user\file#

Example:
  SET base64:value base64#YmFzZTY0#

Note: should not contain any blank character

## Sourcery 总结

通过解码 base64、十六进制和文件输入，在 CLI 命令中添加对二进制数据的支持，相应地更新帮助和补全，并包含测试和必要的依赖项。

新特性：
- 支持带有 base64、十六进制和文件路径解码的二进制 CLI 参数

增强功能：
- 切换 CLI 命令以使用解码后的 Cmd 构建器而不是原始字符串
- 增强帮助命令输出和补全，以包含二进制用法说明

构建：
- 添加 hex crate 依赖项

文档：
- 使用二进制用法示例更新 CLI 帮助文本

测试：
- 为 try_decode_arg 解码逻辑添加单元测试

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Add support for binary data in CLI commands by decoding base64, hex, and file inputs, update help and completion accordingly, and include tests and necessary dependencies.

New Features:
- Support binary CLI arguments with base64, hex, and file path decoding

Enhancements:
- Switch CLI commands to use a decoded Cmd builder instead of raw strings
- Enhance help command output and completion to include binary usage instructions

Build:
- Add hex crate dependency

Documentation:
- Update CLI help text with binary usage examples

Tests:
- Add unit test for try_decode_arg decoding logic

</details>