### PR TITLE
fix: inifinite loop on event listening when startup

### DIFF
--- a/.github/workflows/debug-macos.yml
+++ b/.github/workflows/debug-macos.yml
@@ -1,0 +1,35 @@
+name: Build Specified Target
+
+permissions:
+  contents: read
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        default: "main"
+        required: true
+        description: "Branch to run"
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ macos-latest ]
+        rust: [ stable ]
+
+    steps:
+      - name: Checkout
+        uses: actions/Checkout@v4
+      - name: rust-toolchain
+        uses: dtolnay/rust-toolchain@v1
+        with:
+          toolchain: stable
+      - name: Cargo
+        uses: actions-rs/cargo@v1
+        with:
+          use-cross: true
+          command: build
+      - name: Run
+        run: cargo run

--- a/.github/workflows/debug-macos.yml
+++ b/.github/workflows/debug-macos.yml
@@ -1,4 +1,4 @@
-name: Build Specified Target
+name: Debug MacOS
 
 permissions:
   contents: read

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,6 +92,7 @@ async fn run(mut app: App, mut terminal: TerminalBackEnd, config: Configuration,
     let global_channel = subscribe_global_channel()?;
     let message_channel = subscribe_message_channel()?;
     let input_channel = app.input.receiver();
+    publish_event(GlobalEvent::Dynamic(String::from("start")))?;
     loop {
         if !app.health() {
             break;

--- a/src/main.rs
+++ b/src/main.rs
@@ -153,8 +153,6 @@ async fn run(mut app: App, mut terminal: TerminalBackEnd, config: Configuration,
                                     }
                                 }
                             }
-                        } else {
-                            panic!("{:?}", input);
                         }
                     }
                     InputEvent::State(state) => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -152,6 +152,8 @@ async fn run(mut app: App, mut terminal: TerminalBackEnd, config: Configuration,
                                     }
                                 }
                             }
+                        } else {
+                            panic!("{:?}", input);
                         }
                     }
                     InputEvent::State(state) => {


### PR DESCRIPTION
fix: #78 – By manually send an event to prevent event loop listening on startup that may cause an infinite loop

close #78 