### PR TITLE
CI: build on ubuntu22.04 & macos-13

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,7 +41,7 @@ jobs:
     needs: create_release
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        os: [ubuntu-22.04, macos-latest, windows-latest]
         rust: [stable]
     outputs:
       linux_amd64_sha256: ${{ steps.linux_amd64.outputs.sha256 }}
@@ -60,7 +60,7 @@ jobs:
       run: cargo build --release
     - name: Package (Linux)
       id: linux_amd64
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-22.04'
       run: |
         tar -czvf ./target/release/ratisui-linux-amd64.tar.gz LICENSE README.md -C ./target/release ratisui
         ARCHIVE_SHA256=$(sha256sum ./target/release/ratisui-linux-amd64.tar.gz | awk '{print $1}')
@@ -83,7 +83,7 @@ jobs:
         "sha256=$ARCHIVE_SHA256" >> $env:GITHUB_OUTPUT
       
     - name: Upload Release Asset (Linux)
-      if: matrix.os == 'ubuntu-latest'
+      if: matrix.os == 'ubuntu-22.04'
       uses: actions/upload-release-asset@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -119,7 +119,7 @@ jobs:
     needs: create_release
     strategy:
       matrix:
-        os: [ubuntu-latest]
+        os: [ubuntu-22.04]
         rust: [stable]
     outputs:
       linux_aarch64_sha256: ${{ steps.linux_aarch64.outputs.sha256 }}
@@ -159,29 +159,24 @@ jobs:
     needs: create_release
     strategy:
       matrix:
-        os: [macos-latest]
+        os: [macos-13]
         rust: [stable]
     outputs:
       mac_intel_sha256: ${{ steps.mac_intel.outputs.sha256 }}
     steps:
     - name: Checkout code
       uses: actions/checkout@v4
-    - name: rust-toolchain
-      uses: dtolnay/rust-toolchain@v1
-      with:
-        toolchain: stable
-        target: x86_64-apple-darwin
     - name: Cargo
       uses: actions-rs/cargo@v1
       with:
           use-cross: true
           command: build
-          args: --target x86_64-apple-darwin --release
+          args: --release
     - name: Package (Mac-intel)
       id: mac_intel
       run: |
-        tar -czvf ./target/x86_64-apple-darwin/release/ratisui-mac-intel.tar.gz LICENSE README.md -C ./target/x86_64-apple-darwin/release ratisui
-        ARCHIVE_SHA256=$(shasum -a 256 ./target/x86_64-apple-darwin/release/ratisui-mac-intel.tar.gz | awk '{print $1}')
+        tar -czvf ./target/release/ratisui-mac-intel.tar.gz LICENSE README.md -C ./target/release ratisui
+        ARCHIVE_SHA256=$(shasum -a 256 ./target/release/ratisui-mac-intel.tar.gz | awk '{print $1}')
         echo "sha256=$ARCHIVE_SHA256" >> $GITHUB_OUTPUT
     - name: Upload Release Asset (Mac-intel)
       uses: actions/upload-release-asset@v1
@@ -189,7 +184,7 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ needs.create_release.outputs.upload_url }}
-        asset_path: ./target/x86_64-apple-darwin/release/ratisui-mac-intel.tar.gz
+        asset_path: ./target/release/ratisui-mac-intel.tar.gz
         asset_name: ratisui-mac-intel.tar.gz
         asset_content_type: application/octet-stream
 


### PR DESCRIPTION
### Linux

When building on `ubuntu-24.04`, the linker uses `glibc 2.39`, which prevents the binary from running on older systems like `ubuntu-22.04` (glibc 2.35). To improve compatibility, the Linux version is built using `ubuntu-22.04`.

### Mac

To avoid similar issues on `macos`, the `macos-intel` version is built using `macos-13`. For details, see the [Build Macos](https://github.com/honhimW/ratisui/actions/runs/16987853491/job/48160565544).

### Windows

On Windows, based on [WinGet checks](https://github.com/microsoft/winget-pkgs/pull/282189#issuecomment-3169330662), It seems VC2015+ is required. Compatibility issues with this version are not currently being considered.